### PR TITLE
Allow package filter when scanning annotations

### DIFF
--- a/core/src/main/java/com/jexunit/core/junit/Parameterized.java
+++ b/core/src/main/java/com/jexunit/core/junit/Parameterized.java
@@ -166,16 +166,20 @@ public class Parameterized extends Suite {
     private final ArrayList<Runner> runners = new ArrayList<>();
     private Class<?> testType;
     private String identifier;
-
-    try {
-        final String package = System.getProperty("jexunit.annotation-scan.package");
-        if (package != null && !package.isEmpty()) {
-            detector.detect(package);
-        } else {
-            detector.detect();
+    
+    static {
+        // scan classes for test commands
+        final AnnotationDetector detector = new AnnotationDetector(new TestCommandScanner());
+        try {
+            final String property = System.getProperty("jexunit.annotation-scan.package");
+            if (property != null && !property.isEmpty()) {
+                detector.detect(property);
+            } else {
+                detector.detect();
+            }
+        } catch (final IOException e) {
+            e.printStackTrace();
         }
-    } catch (final IOException e) {
-        e.printStackTrace();
     }
 
 

--- a/core/src/main/java/com/jexunit/core/junit/Parameterized.java
+++ b/core/src/main/java/com/jexunit/core/junit/Parameterized.java
@@ -167,15 +167,17 @@ public class Parameterized extends Suite {
     private Class<?> testType;
     private String identifier;
 
-    static {
-        // scan classes for test commands
-        final AnnotationDetector detector = new AnnotationDetector(new TestCommandScanner());
-        try {
+    try {
+        final String package = System.getProperty("jexunit.annotation-scan.package");
+        if (package != null && !package.isEmpty()) {
+            detector.detect(package);
+        } else {
             detector.detect();
-        } catch (final IOException e) {
-            e.printStackTrace();
         }
+    } catch (final IOException e) {
+        e.printStackTrace();
     }
+
 
     /**
      * Only called reflectively. Do not use programmatically.


### PR DESCRIPTION
Annotation scanning takes a lot of time on a full classpath. The detector accepts a package listing to improve performance.

The annotation scanning happens in a static context so I could not solve it using the jexunit.properties.